### PR TITLE
Fix incorrect Vite config filename in installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ Copy the `.env.example` file to `.env`:
 cp .env.example .env
 ```
 
-Copy the `vite.js.example` file to `vite.js`:
+Copy the `vite.config.js.example` file to `vite.config.js`:
 ```bash
-cp vite.js.example vite.js
+cp vite.config.js.example vite.config.js
 ```
 
 Configure your database settings in the `.env` file: 


### PR DESCRIPTION
### Overview
This pull request addresses an error in the installation guide of the `mailifyflow` project. The guide incorrectly instructs users to rename `vite.js.example` to `vite.js`, whereas the correct filename required by Vite is `vite.config.js`. This fix is particularly important for beginners in the Laravel ecosystem, ensuring they can run the project in their local environment without issues.

### Changes Made
- Updated the documentation to correct the Vite configuration filename from `vite.js` to `vite.config.js`.
- Ensured that all references to the Vite configuration file in the documentation are consistent with Vite's requirements.

### Impact
Correcting this filename in the guide ensures that new users, especially those new to Laravel, will follow the correct steps without encountering configuration errors, promoting a smoother setup experience.

Thanking you for considering this correction. I am eager to assist further and look forward to any feedback!
